### PR TITLE
Use dpkg --print-architecture to determine arch

### DIFF
--- a/debspawn/osbase.py
+++ b/debspawn/osbase.py
@@ -57,9 +57,9 @@ class OSBase:
 
     def _make_name(self):
         if not self._arch:
-            out, _, ret = safe_run(['dpkg-architecture', '-qDEB_HOST_ARCH'])
+            out, _, ret = safe_run(['dpkg', '--print-architecture'])
             if ret != 0:
-                raise Exception('Running dpkg-architecture failed: {}'.format(out))
+                raise Exception('Running dpkg --print-architecture failed: {}'.format(out))
 
             self._arch = out.strip()
         if self._variant:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -72,12 +72,12 @@ def build_arch():
     '''
     from debspawn.utils.command import safe_run
 
-    out, _, ret = safe_run(['dpkg-architecture', '-q', 'DEB_BUILD_ARCH'])
+    out, _, ret = safe_run(['dpkg', '--print-architecture'])
     assert ret == 0
 
     arch = out.strip()
     if not arch:
-        arch = 'amd64'  # assume arm64 as default
+        arch = 'amd64'  # assume amd64 as default
 
     return arch
 


### PR DESCRIPTION
@helmutg's solution to https://bugs.debian.org/987547


Basically, the only thing that dpkg-architecture is being used for is `dpkg-architecture -qDEB_HOST_ARCH`. Its output is used as a fallback when no architecture is provided by the user. It is intended to serve the architecture of the running system (even though that's not quite what it does). A simpler way to do that is dpkg --print-architecture and in doing so, the dpkg-dev dependency is avoided.