### PR TITLE
Fix package pinning when specifying a suite by its release codename

### DIFF
--- a/debspawn/osbase.py
+++ b/debspawn/osbase.py
@@ -447,7 +447,7 @@ class OSBase:
                 priority = 500
                 if suite == self.suite:
                     priority = 600
-                f.write(('Package: *\n' 'Pin: release a={}\n' 'Pin-Priority: {}\n').format(suite, priority))
+                f.write(('Package: *\n' 'Pin: release {}\n' 'Pin-Priority: {}\n').format(suite, priority))
 
                 # we *always* prefer locally injected packages above anything else
                 f.write('\nPackage: *\nPin: release o=LocalInjected\nPin-Priority: 1000\n')


### PR DESCRIPTION
Previously, pinning would work when using something like this:

    debspawn create --suite=stable-backports --base-suite=stable ...

but packages would fail to install when using something like this:

    debspawn create --suite=bookworm-backports --base-suite=bookworm ...